### PR TITLE
Added request mapping of "/" to reactjs app for convenience and updated unit test

### DIFF
--- a/camunda-reactjs-demo/src/main/java/com/camunda/poc/starter/controller/ui/UiApplicationController.java
+++ b/camunda-reactjs-demo/src/main/java/com/camunda/poc/starter/controller/ui/UiApplicationController.java
@@ -13,9 +13,17 @@ public class UiApplicationController {
 	public UiApplicationController() {
 	}
 
-	@RequestMapping("/app.html")
-	public String index() {
+	private String homePage() {
 		return "app";
+	}
+	@RequestMapping("/")
+	public String index() {
+		return homePage();
+	}
+
+	@RequestMapping("/app.html")
+	public String app() {
+		return homePage();
 	}
 
 }

--- a/camunda-reactjs-demo/src/test/java/com/camunda/poc/starter/controller/MessageControllerTest.java
+++ b/camunda-reactjs-demo/src/test/java/com/camunda/poc/starter/controller/MessageControllerTest.java
@@ -1,29 +1,37 @@
 package com.camunda.poc.starter.controller;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
+@AutoConfigureMockMvc
 public class MessageControllerTest {
 
     @Autowired
+    private WebApplicationContext webApplicationContext;
     private MockMvc mvc;
+
+    @Before
+    public void setUp() {
+        mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
     
     @Test
     public void getHello() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.post("/parse", "","","","").accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string(equalTo(HttpStatus.OK)));
+        mvc.perform(MockMvcRequestBuilders.get("/"))
+                .andExpect(status().isOk());
     }
     
 }


### PR DESCRIPTION
Hi Paul, this is a very small change to make it slightly more convenient to browse to the reactjs app. This makes it possible to use either http://localhost:3000 or http://localhost:3000/app.html. 

But, more importantly, I wanted to send a pull request to (1) make sure I remember how to submit pull requests(!), and (2) gauge whether sending pull requests like this is a good way to collaborate?

I think going thru the code and adding little conveniences like this might be a good way for me to learn more about the project?

Let me know what you think!
Thanks!
Dave
